### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/isaac-fuzhuli/fa94320a-2280-4d6e-ade2-4e16e7d89ddf/577c9db9-abd4-4fe3-9581-6dc0326bd5eb/_apis/work/boardbadge/31ecccd3-814c-4eb7-9eb3-cda423687bb7)](https://dev.azure.com/isaac-fuzhuli/fa94320a-2280-4d6e-ade2-4e16e7d89ddf/_boards/board/t/577c9db9-abd4-4fe3-9581-6dc0326bd5eb/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://dev.azure.com/isaac-fuzhuli/fa94320a-2280-4d6e-ade2-4e16e7d89ddf/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.